### PR TITLE
Change deprecated uses

### DIFF
--- a/src/layers/CrossEntropyLoss.jl
+++ b/src/layers/CrossEntropyLoss.jl
@@ -30,7 +30,7 @@ function forward(l::CrossEntropyLoss, Y::Array{Float64,2}, label::Array{Float64,
   @assert size(Y) == size(label)
   @assert size(l.x) == size(Y)
 
-  l.x = log(Y)
+  l.x = log.(Y)
   l.x = -label.*l.x
   # broadcast!(*, -l.x, label)
   l.loss = sum(l.x,2)

--- a/src/layers/LayerBase.jl
+++ b/src/layers/LayerBase.jl
@@ -1,11 +1,11 @@
-abstract ANN
-abstract Layer
-abstract LearnableLayer <: Layer
-abstract Nonlinearity   <: Layer
-abstract LossCriteria   <: Layer
-abstract DataLayer      <: Layer
-abstract RegularizationLayer <: Layer
-abstract UtilityLayer <: Layer
+abstract type ANN end
+abstract type Layer end
+abstract type LearnableLayer <: Layer end
+abstract type Nonlinearity   <: Layer end
+abstract type LossCriteria   <: Layer end
+abstract type DataLayer      <: Layer end
+abstract type RegularizationLayer <: Layer end
+abstract type UtilityLayer <: Layer end
 
 StaticLayer = Union{Nonlinearity, DataLayer, RegularizationLayer, UtilityLayer}
 

--- a/src/layers/SoftMax.jl
+++ b/src/layers/SoftMax.jl
@@ -34,7 +34,7 @@ function forward(l::SoftMax, X::Array{Float64,2}; kwargs...)
 
     l.x = X
     # iterating each row/picture
-    l.lexp = exp(l.x)
+    l.lexp = exp.(l.x)
     l.lsum = sum(l.lexp, 2)
     # l.y = l.lexp./l.lsum
     broadcast!(/, l.y, l.lexp, l.lsum)

--- a/src/layers/SoftMaxCrossEntropy.jl
+++ b/src/layers/SoftMaxCrossEntropy.jl
@@ -63,7 +63,7 @@ function forward(l::SoftMaxCrossEntropyLoss, Y::Array{Float64,2}, label::Array{I
         update(l, size(Y))
     end
     broadcast!(-, l.x, Y, maximum(Y, 2))
-    broadcast!(-, l.y, log(sum(exp(l.x),2)), l.x)
+    broadcast!(-, l.y, log.(sum(exp.(l.x),2)), l.x)
     for i = 1:N
         l.label[i] = label[i] + 1
     end
@@ -103,7 +103,7 @@ function backward(l::SoftMaxCrossEntropyLoss, label::Array{Int, 2};kwargs...)
 
     # local Y = l.x
     # Y = exp(broadcast(+, Y, - maximum(Y,2)))
-    l.dldx = exp(l.x)
+    l.dldx = exp.(l.x)
     broadcast!(/, l.dldx, l.dldx, sum(l.dldx,2))
     broadcast!(-, l.dldx, l.dldx, l.target)
     # return Y .- TAR


### PR DESCRIPTION
Change deprecated uses according to Julia 0.6.0 warnings.
Please review that the changes are compatible with Julia 0.5.1