### PR TITLE
Added 'update' function for softmax

### DIFF
--- a/src/layers/SoftMax.jl
+++ b/src/layers/SoftMax.jl
@@ -30,8 +30,21 @@ function init(l::SoftMax, p::Union{Layer,Void}, config::Dict{String,Any}; kwargs
   l.lexp = Array{Float64}(out_size)
 end
 
-function forward(l::SoftMax, X::Array{Float64,2}; kwargs...)
+function update(l::SoftMax, output_size::Tuple)
+    l.x = Array{Float64}(out_size)
+    l.y = Array{Float64}(out_size)
+    l.has_init = true;
+    m,n = out_size
+    l.jacobian = Array{Float64}(n,n)
+    l.dldx = Array{Float64}(out_size)
+    l.ly = Array{Float64}(n)
+    l.lexp = Array{Float64}(out_size)
+end
 
+function forward(l::SoftMax, X::Array{Float64,2}; kwargs...)
+    if size(l.x) != size(X)
+        update(l, size(X))
+    end
     l.x = X
     # iterating each row/picture
     l.x = l.x .- maximum(l.x, 2)
@@ -45,6 +58,7 @@ end
 
 function backward(l::SoftMax, DLDY::Array{Float64, 2}; kwargs...)
     # credits: https://stats.stackexchange.com/questions/79454/softmax-layer-in-a-neural-network?newreg=d1e89b443dd346ae8bccaf038a944221
+    @assert size(l.y) == size(DLDY)
     m,n =size(l.x)
     for batch=1:m
       l.ly = l.y[batch,:]


### PR DESCRIPTION
I did not realized the use of such 'update' functions in some of the layers until recently, so I append the function and check for 'Softmax' modeling over the one in 'Sigmoid'. I wonder if one is also necessary for 'CrossEntropy', but another loss function, `SquareLoss` does not implement such `update` function. Happy to commit further for adding either test for `Softmax`'s case for update or `update` functions for both loss functions.