### PR TITLE
New design

### DIFF
--- a/examples/mnist.jl
+++ b/examples/mnist.jl
@@ -3,29 +3,16 @@ include("util/datasets.jl")
 
 batch_size = 500
 
-function build_graph()
-    l0 = InputLayer(Void, (28,28,1,batch_size))
-
-    l1 = CaffeConvLayer(l0, 32,(5,5))
-    l2 = ReLu(l1)
-    l3 = MaxPoolingLayer(l2, (2,2))
-
-    l4 = CaffeConvLayer(l3, 32,(5,5))
-    l5 = ReLu(l4)
-    l6 = MaxPoolingLayer(l5, (2,2))
-
-    l7 = FlattenLayer(l6)
-
-    l8 = DenseLayer(l7, 256)
-    l9 = ReLu(l8)
-
-    l10 = DropoutLayer(l9, 0.5)
-    l11 = DenseLayer(l10, 10)
-
-    l12 = SoftMaxCrossEntropyLoss(l11)
-
-    graph = Graph(l12)
-    return graph
+function build_model()
+    input = InputLayer((batch_size,784)),
+    l1    = DenseLayer(input, 1000; init_type = "Normal"),
+    l2    = ReLu(l1),
+    l3    = DropoutLayer(l2, 0.5),
+    l4    = DenseLayer(l3, 1000; init_type = "Normal" ),
+    l5    = ReLu(l4),
+    l6    = DropoutLayer(l5, 0.5),
+    l7    = DenseLayer(l6, 10; init_type = "Normal")
+    return Graph(l7)
 end
 
 function get_corr(pred, answ)
@@ -102,7 +89,7 @@ println("TrainSet: $(size(trX)) $(size(trY))")
 println("ValSet  : $(size(valX)) $(size(valY))")
 println("TestSet : $(size(teX)) $(size(teY))")
 
-graph = build_graph()
+graph = s()
 
 epo_losses, epo_accu, val_losses, val_accu, all_losses = sgd(
     net, (trX, trY), (valX, valY);
@@ -116,4 +103,3 @@ plot(1:length(all_losses), all_losses)
 title("SGD Graph: Training losses")
 
 show()
-

--- a/src/layers/Graph.jl
+++ b/src/layers/Graph.jl
@@ -24,9 +24,9 @@ function top_sort(graph::Graph, layer::Layer, visited::Set{Layer})
     end
 end
 
-function forward(graph::Graph, xs::Dict{String, <:Array{Float64}}; kwargs...)
-    for (tag, input) in xs
-        forward(graph.input_layers[tag], input;kwargs...)
+function forward(graph::Graph, xs::Dict{<:Layer, <:Array{Float64}}; kwargs...)
+    for (input_layer, input) in xs
+        forward(input_layer, input; kwargs...)
     end
     forward_the_rest(graph; kwargs...)
     # loss and prediction from the loss layer, which is assumed to be the last

--- a/src/layers/InputLayer.jl
+++ b/src/layers/InputLayer.jl
@@ -6,17 +6,7 @@ type InputLayer <: DataLayer
     shape   :: Tuple
     tag     :: String
 
-
-    function InputLayer(shape; tag="default")
-        # TODO: could allocate less memory by having only two arrays to pass around
-        layer = new(LayerBase(), Float64[], shape, tag)
-        # are below necessary?
-        # layer.base.y = Array{Float64}(shape)
-        # layer.base.dldy = Array{Float64}(shape)
-        layer
-    end
-
-    function InputLayer(shape, config::Union{Dict{String,Any},Void}=nothing;tag="default")
+    function InputLayer(shape::Tuple; tag="default")
         layer = new(LayerBase(), Float64[], shape, tag)
         # layer.base.y = Array{Float64}(shape)
         # layer.base.dldy = Array{Float64}(shape)
@@ -24,10 +14,7 @@ type InputLayer <: DataLayer
     end
 end
 
-function init(l::InputLayer, p::Union{Layer,Void}, config::Union{Dict{String,Any},Void}; kwargs...)
-end
-
-function update(l::InputLayer, input_size::Tuple;)
+function update(l::InputLayer, input_size::Tuple)
     # Reinitialize the memory due to the updated of the batch_size
     l.shape = input_size
     # println("Input layer shape update:$(l.shape)")
@@ -39,10 +26,6 @@ function forward(l::InputLayer, X::Union{SubArray{Float64},Array{Float64}}; kwar
     end
     l.base.y = X
     return l.base.y
-end
-
-function backward(l::InputLayer; kwargs...)
-    backward(l, sum(map(x -> x.base.dldx[l.base.id], l.base.children)))
 end
 
 function backward(l::InputLayer, DLDY::Array{Float64}; kwargs...)

--- a/src/layers/LayerBase.jl
+++ b/src/layers/LayerBase.jl
@@ -28,6 +28,15 @@ function connect(l::Layer, parents::Array{<:Layer})
     end
 end
 
+function forward(l ::Layer; kwargs...)
+	forward(l, l.base.parents[1].base.y; kwargs...)
+end
+
+function backward(l ::Layer; kwargs...)
+    DLDY = sum(map(x -> x.base.dldx[l.base.id], l.base.children))
+    backward(l, DLDY; kwargs...)
+end
+
 StaticLayer = Union{Nonlinearity, DataLayer, RegularizationLayer, UtilityLayer}
 
 function getGradient(l::StaticLayer)

--- a/test/InputLayerTest.jl
+++ b/test/InputLayerTest.jl
@@ -4,13 +4,8 @@ include("../src/layers/SoftMaxCrossEntropy.jl")
 import Calculus: check_gradient
 using Base.Test
 
-function beforeTest()
-    return InputLayer((1,2))
-end
-
-
 function testInputLayerOneVector(x, y, dldy, dldx)
-    l = beforeTest()
+    l = InputLayer(size(x))
     l2 = SoftMaxCrossEntropyLoss(l)
 
     # Testing forwarding

--- a/test/ReLuTest.jl
+++ b/test/ReLuTest.jl
@@ -7,7 +7,6 @@ using Base.Test
 function testReLuOneVector(x, y, dldy, dldx; alpha = 1.)
     l0 = InputLayer(size(x))
     l  = ReLu(l0)
-    l1 = Softma
 
     # Testing forwarding
     forward(l0, x)


### PR DESCRIPTION
# Change Interface
1. separate constructors for: 
- when there is a previous layer, use the previous layer to preallocate memory
- when there is no previous layer, use a configuration dictionary to preallocate memory
2. use a base object to store common parameters
3. feed in Dictionary has layers as keys
4. Collect common structure for backward and forward in LayerBase.jl